### PR TITLE
Test the Proxies features

### DIFF
--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -220,7 +220,7 @@ class Site
      */
     function getCertificates($path = null)
     {
-        $path = is_null($path) ? $this->certificatesPath() : $path;
+        $path = $path ?: $this->certificatesPath();
 
         $this->files->ensureDirExists($path, user());
 

--- a/tests/fixtures/Proxies/Nginx/not-a-proxy.com.test
+++ b/tests/fixtures/Proxies/Nginx/not-a-proxy.com.test
@@ -1,0 +1,90 @@
+# valet stub: proxy.valet.conf
+
+server {
+    listen 127.0.0.1:80;
+    server_name not-a-proxy.com.test www.not-a-proxy.com.test *.not-a-proxy.com.test;
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 127.0.0.1:443 ssl http2;
+    server_name not-a-proxy.com.test www.not-a-proxy.com.test *.not-a-proxy.com.test;
+    root /;
+    charset utf-8;
+    client_max_body_size 128M;
+    http2_push_preload on;
+
+    location /41c270e4-5535-4daa-b23e-c269744c2f45/ {
+        internal;
+        alias /;
+        try_files $uri $uri/;
+    }
+
+    ssl_certificate "/home/nobody/.config/valet/Certificates/not-a-proxy.com.test.crt";
+    ssl_certificate_key "/home/nobody/.config/valet/Certificates/not-a-proxy.com.test.key";
+
+    location = /favicon.ico { access_log off; log_not_found off; }
+    location = /robots.txt  { access_log off; log_not_found off; }
+
+    access_log off;
+    error_log "/home/nobody/.config/valet/Log/not-a-proxy.com.test-error.log";
+
+    error_page 404 "/home/nobody/.composer/vendor/laravel/valet/server.php";
+
+    location ~ \.php$ {
+        fastcgi_split_path_info ^(.+\.php)(/.+)$;
+        fastcgi_pass php:9000;
+        fastcgi_index index.php;
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_intercept_errors off;
+        fastcgi_buffer_size 16k;
+        fastcgi_buffers 4 16k;
+        fastcgi_param PHP_VALUE "memory_limit = -1";
+    }
+
+    location ~ /\.ht {
+        deny all;
+    }
+}
+
+server {
+    listen 127.0.0.1:60;
+    server_name not-a-proxy.com.test www.not-a-proxy.com.test *.not-a-proxy.com.test;
+    root /;
+    charset utf-8;
+    client_max_body_size 128M;
+
+    add_header X-Robots-Tag 'noindex, nofollow, nosnippet, noarchive';
+
+    location /41c270e4-5535-4daa-b23e-c269744c2f45/ {
+        internal;
+        alias /;
+        try_files $uri $uri/;
+    }
+
+    location = /favicon.ico { access_log off; log_not_found off; }
+    location = /robots.txt  { access_log off; log_not_found off; }
+
+    access_log off;
+    error_log "/home/nobody/.config/valet/Log/not-a-proxy.com.test-error.log";
+
+    error_page 404 "/home/nobody/.composer/vendor/laravel/valet/server.php";
+
+    location ~ \.php$ {
+        fastcgi_split_path_info ^(.+\.php)(/.+)$;
+        fastcgi_pass php:9000;
+        fastcgi_index index.php;
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_intercept_errors off;
+        fastcgi_buffer_size 16k;
+        fastcgi_buffers 4 16k;
+        fastcgi_param PHP_VALUE "memory_limit = -1";
+    }
+
+    location ~ /\.ht {
+        deny all;
+    }
+}
+

--- a/tests/fixtures/Proxies/Nginx/some-other-proxy.com.test
+++ b/tests/fixtures/Proxies/Nginx/some-other-proxy.com.test
@@ -1,0 +1,95 @@
+# valet stub: proxy.valet.conf
+
+server {
+    listen 127.0.0.1:80;
+    server_name some-other-proxy.com.test www.some-other-proxy.com.test *.some-other-proxy.com.test;
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 127.0.0.1:443 ssl http2;
+    server_name some-other-proxy.com.test www.some-other-proxy.com.test *.some-other-proxy.com.test;
+    root /;
+    charset utf-8;
+    client_max_body_size 128M;
+    http2_push_preload on;
+
+    location /41c270e4-5535-4daa-b23e-c269744c2f45/ {
+        internal;
+        alias /;
+        try_files $uri $uri/;
+    }
+
+    ssl_certificate "/home/nobody/.config/valet/Certificates/some-other-proxy.com.test.crt";
+    ssl_certificate_key "/home/nobody/.config/valet/Certificates/some-other-proxy.com.test.key";
+
+    location = /favicon.ico { access_log off; log_not_found off; }
+    location = /robots.txt  { access_log off; log_not_found off; }
+
+    access_log off;
+    error_log "/home/nobody/.config/valet/Log/some-other-proxy.com.test-error.log";
+
+    error_page 404 "/home/nobody/.composer/vendor/laravel/valet/server.php";
+
+    location / {
+        proxy_pass https://127.0.0.1:8443;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+        proxy_set_header   X-Client-Verify   SUCCESS;
+        proxy_set_header   X-Client-DN       $ssl_client_s_dn;
+        proxy_set_header   X-SSL-Subject     $ssl_client_s_dn;
+        proxy_set_header   X-SSL-Issuer      $ssl_client_i_dn;
+        proxy_set_header   X-NginX-Proxy true;
+        proxy_set_header   Upgrade $http_upgrade;
+        proxy_set_header   Connection "upgrade";
+        proxy_http_version 1.1;
+        proxy_read_timeout 1800;
+        proxy_connect_timeout 1800;
+        chunked_transfer_encoding on;
+        proxy_redirect off;
+        proxy_buffering off;
+    }
+
+    location ~ /\.ht {
+        deny all;
+    }
+}
+
+server {
+    listen 127.0.0.1:60;
+    server_name some-other-proxy.com.test www.some-other-proxy.com.test *.some-other-proxy.com.test;
+    root /;
+    charset utf-8;
+    client_max_body_size 128M;
+
+    add_header X-Robots-Tag 'noindex, nofollow, nosnippet, noarchive';
+
+    location /41c270e4-5535-4daa-b23e-c269744c2f45/ {
+        internal;
+        alias /;
+        try_files $uri $uri/;
+    }
+
+    location = /favicon.ico { access_log off; log_not_found off; }
+    location = /robots.txt  { access_log off; log_not_found off; }
+
+    access_log off;
+    error_log "/home/nobody/.config/valet/Log/some-other-proxy.com.test-error.log";
+
+    error_page 404 "/home/nobody/.composer/vendor/laravel/valet/server.php";
+
+    location / {
+        proxy_pass https://127.0.0.1:8443;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+    }
+
+    location ~ /\.ht {
+        deny all;
+    }
+}
+

--- a/tests/fixtures/Proxies/Nginx/some-proxy.com.test
+++ b/tests/fixtures/Proxies/Nginx/some-proxy.com.test
@@ -1,0 +1,95 @@
+# valet stub: proxy.valet.conf
+
+server {
+    listen 127.0.0.1:80;
+    server_name some-proxy.com.test www.some-proxy.com.test *.some-proxy.com.test;
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 127.0.0.1:443 ssl http2;
+    server_name some-proxy.com.test www.some-proxy.com.test *.some-proxy.com.test;
+    root /;
+    charset utf-8;
+    client_max_body_size 128M;
+    http2_push_preload on;
+
+    location /41c270e4-5535-4daa-b23e-c269744c2f45/ {
+        internal;
+        alias /;
+        try_files $uri $uri/;
+    }
+
+    ssl_certificate "/home/nobody/.config/valet/Certificates/some-proxy.com.test.crt";
+    ssl_certificate_key "/home/nobody/.config/valet/Certificates/some-proxy.com.test.key";
+
+    location = /favicon.ico { access_log off; log_not_found off; }
+    location = /robots.txt  { access_log off; log_not_found off; }
+
+    access_log off;
+    error_log "/home/nobody/.config/valet/Log/some-proxy.com.test-error.log";
+
+    error_page 404 "/home/nobody/.composer/vendor/laravel/valet/server.php";
+
+    location / {
+        proxy_pass https://127.0.0.1:8443;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+        proxy_set_header   X-Client-Verify   SUCCESS;
+        proxy_set_header   X-Client-DN       $ssl_client_s_dn;
+        proxy_set_header   X-SSL-Subject     $ssl_client_s_dn;
+        proxy_set_header   X-SSL-Issuer      $ssl_client_i_dn;
+        proxy_set_header   X-NginX-Proxy true;
+        proxy_set_header   Upgrade $http_upgrade;
+        proxy_set_header   Connection "upgrade";
+        proxy_http_version 1.1;
+        proxy_read_timeout 1800;
+        proxy_connect_timeout 1800;
+        chunked_transfer_encoding on;
+        proxy_redirect off;
+        proxy_buffering off;
+    }
+
+    location ~ /\.ht {
+        deny all;
+    }
+}
+
+server {
+    listen 127.0.0.1:60;
+    server_name some-proxy.com.test www.some-proxy.com.test *.some-proxy.com.test;
+    root /;
+    charset utf-8;
+    client_max_body_size 128M;
+
+    add_header X-Robots-Tag 'noindex, nofollow, nosnippet, noarchive';
+
+    location /41c270e4-5535-4daa-b23e-c269744c2f45/ {
+        internal;
+        alias /;
+        try_files $uri $uri/;
+    }
+
+    location = /favicon.ico { access_log off; log_not_found off; }
+    location = /robots.txt  { access_log off; log_not_found off; }
+
+    access_log off;
+    error_log "/home/nobody/.config/valet/Log/some-proxy.com.test-error.log";
+
+    error_page 404 "/home/nobody/.composer/vendor/laravel/valet/server.php";
+
+    location / {
+        proxy_pass https://127.0.0.1:8443;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+    }
+
+    location ~ /\.ht {
+        deny all;
+    }
+}
+


### PR DESCRIPTION
Updated the `proxies` method to return the URL + .tld as the rendered output wasn't exactly what one would expect. While not critical, it was not consistent.

Refactored some of the Site class to aid in testing using a fake instead of relying on a ton of mocking.

The Site fake has support for both using `tests/output` as well as named fixtures (`tests/fixtures/Proxies`).

Testing for certificate I/O is pretty whack, but this is the best I could come up with that would still ensure the certificate stuff was getting called without actually requiring `sudo` to run phpunit.

Replaced instances referring directly to `VALET_HOME_PATH` with calls to the new `valetHomePath()`. This method is taken over in the fake Site implementation so that everything runs the same using the fake Site without having to change other assumptions.

Updated several "path" methods (and many of their usages) to take the "thing" you are looking for so you can either get the path to the type of "thing" you are looking for or the direct path to the specific "thing" you are looking for.

Examples:

```
// ~/.config/valet/Nginx
$site->nginxPath();

// ~/.config/valet/Nginx/some-site.com.test
$site->nginxPath('some-site.com.test');
```

Made some other tests related to the existence of `Sites` directory that resulted in updating the mocks for many of the other tests.

All in all, it should make other aspects of the Site class handle things more gracefully if `Sites` doesn't exist.

See: laravel/valet#913